### PR TITLE
fix: redis parser when value is undefined

### DIFF
--- a/src/angular/factory/p3xr-redis-parser.js
+++ b/src/angular/factory/p3xr-redis-parser.js
@@ -36,9 +36,10 @@ p3xr.ng.factory('p3xrRedisParser', function ($rootScope) {
                     currentSectionObj = {}
                 } else if (line.length > 2) {
                     const lineArray = line.split(':')
-                    currentSectionObj[lineArray[0]] = lineArray[1].includes(',') ? selfMain.array({
-                        line: lineArray[1].trim()
-                    }) : lineArray[1].trim()
+                    const value = lineArray[1] ?? "";
+                    currentSectionObj[lineArray[0]] = value.includes(',') ? selfMain.array({
+                        line: value.trim()
+                    }) : value.trim()
                 }
             }
             if (section !== undefined) {


### PR DESCRIPTION
Hi, @p3x-robot 

This PR solves the problem referenced in this url [https://github.com/patrikx3/redis-ui/issues/98](url).

When we try to work with pikadb [https://hub.docker.com/r/pikadb/pika](url) seems like exec an info command without value but the function `p3xrRedisParser` always expects a value. In this case the value is `undefined` and `trim()` launch an error.


Thank you for your amazing work,

Regards
